### PR TITLE
Fix Python binding build for pip/uv install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(battery_state_subscriber example/low_level/battery_state_subscrib
 
 
 
-include_directories(BEFORE $(PROJECT_SOURCE_DIR)/include)
+include_directories(BEFORE ${PROJECT_SOURCE_DIR}/include)
 
 if(BUILD_PYTHON_BINDING)
     find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
@@ -44,6 +44,7 @@ if(BUILD_PYTHON_BINDING)
     find_package(pybind11 CONFIG REQUIRED)
 
     python3_add_library(booster_robotics_sdk_python MODULE python/binding.cpp WITH_SOABI)
+    target_link_libraries(booster_robotics_sdk_python PRIVATE pybind11::headers)
 
     target_compile_definitions(booster_robotics_sdk_python PRIVATE VERSION_INFO=${PROJECT_VERSION})
 
@@ -55,10 +56,10 @@ if(BUILD_PYTHON_BINDING)
     add_custom_command(
         TARGET booster_robotics_sdk_python
         POST_BUILD
-        COMMAND PYTHONPATH=${CMAKE_SOURCE_DIR}/build:/${PYTHONPATH} pybind11-stubgen -o ${CMAKE_SOURCE_DIR}/build booster_robotics_sdk_python
+        COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}" pybind11-stubgen -o ${CMAKE_CURRENT_BINARY_DIR} booster_robotics_sdk_python
     )
 
-    install(TARGETS booster_robotics_sdk_python LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES})
-    install(FILES ${CMAKE_SOURCE_DIR}/build/booster_robotics_sdk_python.pyi DESTINATION ${PYTHON_SITE_PACKAGES})    
+    install(TARGETS booster_robotics_sdk_python LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/booster_robotics_sdk_python.pyi DESTINATION ${SKBUILD_PLATLIB_DIR} OPTIONAL)    
 endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.3.3", "pybind11"]
+requires = ["scikit-build-core>=0.3.3", "pybind11", "pybind11-stubgen"]
 build-backend = "scikit_build_core.build"
 
 
@@ -30,6 +30,7 @@ test = ["pytest"]
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true
+cmake.define.BUILD_PYTHON_BINDING = "ON"
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- Fix CMake syntax bug: `$(PROJECT_SOURCE_DIR)` → `${PROJECT_SOURCE_DIR}` (Make syntax vs CMake syntax, breaks Ninja builds)
- Link `pybind11::headers` to the Python binding target so the build environment's pybind11 is used instead of falling back to potentially incompatible system headers
- Add `pybind11-stubgen` to `build-system.requires` so `pip install .` works without manual pre-installation
- Fix `pybind11-stubgen` post-build command to use `CMAKE_CURRENT_BINARY_DIR` instead of hardcoded `${CMAKE_SOURCE_DIR}/build` (broken for out-of-source / isolated builds)
- Enable `BUILD_PYTHON_BINDING` via scikit-build cmake defines
- Use `SKBUILD_PLATLIB_DIR` for install destinations

## Test plan

- [x] `pip install .` / `uv add .` from the SDK root now builds and installs the Python bindings successfully
- [x] `import booster_robotics_sdk_python` works after install
- [x] Verified with Python 3.13 + pybind11 3.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)